### PR TITLE
Porting to Python 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,32 +10,31 @@ This repository is a fork of [glutanimate/PDFMtEd](https://github.com/glutanimat
 
 ## Table of contents
 
-<!-- MarkdownTOC -->
-
 - [Components](#components)
-    - [PDFMtEd Editor](#pdfmted-editor)
-    - [PDFMtEd Inspector](#pdfmted-inspector)
-    - [PDFMtEd Thumbnailer](#pdfmted-thumbnailer)
+  * [PDFMtEd Editor](#pdfmted-editor)
+  * [PDFMtEd Inspector](#pdfmted-inspector)
+  * [PDFMtEd Thumbnailer](#pdfmted-thumbnailer)
 - [Installation and dependencies](#installation-and-dependencies)
-    - [Dependencies](#dependencies)
-        - [Overview of all dependencies](#overview-of-all-dependencies)
-        - [Dependency breakdown](#dependency-breakdown)
-    - [Installation](#installation)
-    - [Uninstall PDFMtEd](#uninstall-pdfmted)
+  * [Dependencies](#dependencies)
+    + [Ubuntu 16.04 or lower](#ubuntu-1604-or-lower)
+    + [Ubuntu 18.04 or higher, Debian, Linux Mint, Pop!OS, Zorin OS, Elementary OS, and any other Linux distribution based on Debian or Ubuntu](#ubuntu-1804-or-higher--debian--linux-mint--pop-os--zorin-os--elementary-os--and-any-other-linux-distribution-based-on-debian-or-ubuntu)
+    + [Fedora, and most other Linux distribution based on Fedora](#fedora--and-most-other-linux-distribution-based-on-fedora)
+    + [Arch Linux, Manjaro](#arch-linux--manjaro)
+    + [Dependency breakdown](#dependency-breakdown)
+  * [Installation](#installation)
+  * [Uninstall PDFMtEd](#uninstall-pdfmted)
 - [Usage](#usage)
-    - [General usage](#general-usage)
-    - [PDFMtEd Editor](#pdfmted-editor-1)
-        - [User interface](#user-interface)
-        - [Command-line options](#command-line-options)
-    - [PDFMtEd Inspector](#pdfmted-inspector-1)
-    - [PDFMtEd Thumbnailer](#pdfmted-thumbnailer-1)
+  * [General usage](#general-usage)
+  * [PDFMtEd Editor](#pdfmted-editor-1)
+    + [User interface](#user-interface)
+    + [Command-line options](#command-line-options)
+  * [PDFMtEd Inspector](#pdfmted-inspector-1)
+  * [PDFMtEd Thumbnailer](#pdfmted-thumbnailer-1)
 - [Additional information](#additional-information)
-    - [Modified metadata tags](#modified-metadata-tags)
-    - [Purging metadata](#purging-metadata)
+  * [Modified metadata tags](#modified-metadata-tags)
+  * [Purging metadata](#purging-metadata)
 - [Known issues](#known-issues)
 - [License](#license)
-
-<!-- /MarkdownTOC -->
 
 ## Components
 
@@ -84,11 +83,14 @@ PDFMtEd Thumbnailer should be able to generate thumbnails for all file types sup
 
 ## Installation and dependencies
 
-The following instructions are provided for Ubuntu. Package names and repositories might differ on other distributions.
+The following instructions are provided for most Linux distributions.
 
 ### Dependencies
 
-#### Overview of all dependencies
+
+*Optional but recommended*: [sejda-console](https://github.com/torakiki/sejda/releases)
+
+#### Ubuntu 16.04 or lower
 
 Install all dependencies on Ubuntu with the following commands:
 
@@ -96,7 +98,18 @@ Install all dependencies on Ubuntu with the following commands:
     sudo apt-get update
     sudo apt-get install yad libimage-exiftool-perl qpdf
 
-*Optional but recommended*: [sejda-console](https://github.com/torakiki/sejda/releases)
+
+#### Ubuntu 18.04 or higher, Debian, Linux Mint, Pop!OS, Zorin OS, Elementary OS, and any other Linux distribution based on Debian or Ubuntu
+
+    sudo apt install libimage-exiftool-perl yad qpdf
+
+#### Fedora, and most other Linux distribution based on Fedora
+
+    sudo dnf install perl-Image-ExifTool yad qpdf
+
+#### Arch Linux, Manjaro
+
+    sudo pacman -S perl-image-exiftool yad qpdf
 
 #### Dependency breakdown
 
@@ -131,7 +144,7 @@ After the installation PDFMtEd Editor and Inspector should be available as entri
 
 ![file manager context menu with PDFMtEd entries](https://github.com/Glutanimate/PDFMtEd/blob/master/screenshots/pdfmted_usage.png)
 
-If you can't find the entries click on *Other application* (arrow) and navigate to *Show other applications*. You should be able to find the PDFMtEd launchers in the list. Double-click on *PDFMtEd – Inspector* to open the application. This will automatically add a context menu entry. Repeat the procedure for *PDFMtEd – Editor* and you are set.
+If you can't find the entries click on *Other application* (arrow) and navigate to *Show other applications*. You should be able to find the PDFMtEd launchers in the list. Double-click on *PDFMtEd  Inspector* to open the application. This will automatically add a context menu entry. Repeat the procedure for *PDFMtEd  Editor* and you are set.
 
 ### Uninstall PDFMtEd
 
@@ -144,6 +157,7 @@ Follow these steps to uninstall the PDFMted utilities:
 2. Run `uninstall.sh` as root:
 
         sudo ./uninstall.sh
+
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@
 
 **PDFMtEd** (**PDF** <b>M</b>e<b>t</b>adata <b>Ed</b>itor) is a set of tools designed to simplify working with PDF metadata on Linux. The utilities hosted in this repository are graphical front-ends to the marvelous [ExifTool](http://www.sno.phy.queensu.ca/~phil/exiftool/) by Phil Harvey.
 
-This repository is a fork of [glutanimate/PDFMtEd](https://github.com/glutanimate/PDFMtEd), ported to Python 3.
-
 ## Table of contents
 
 - [Components](#components)

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ This repository is a fork of [glutanimate/PDFMtEd](https://github.com/glutanimat
 - [Installation and dependencies](#installation-and-dependencies)
   * [Dependencies](#dependencies)
     + [Ubuntu 16.04 or lower](#ubuntu-1604-or-lower)
-    + [Ubuntu 18.04 or higher, Debian, Linux Mint, Pop!OS, Zorin OS, Elementary OS, and any other Linux distribution based on Debian or Ubuntu](#ubuntu-1804-or-higher--debian--linux-mint--pop-os--zorin-os--elementary-os--and-any-other-linux-distribution-based-on-debian-or-ubuntu)
-    + [Fedora, and most other Linux distribution based on Fedora](#fedora--and-most-other-linux-distribution-based-on-fedora)
-    + [Arch Linux, Manjaro](#arch-linux--manjaro)
+    + [Most other Linux distribution based on Debian or Ubuntu](#most-other-linux-distribution-based-on-debian-or-ubuntu)
+    + [Fedora and most other Linux distribution based on Fedora](#fedora-and-most-other-linux-distribution-based-on-fedora)
+    + [Arch Linux or Manjaro](#arch-linux-or-manjaro)
     + [Dependency breakdown](#dependency-breakdown)
   * [Installation](#installation)
   * [Uninstall PDFMtEd](#uninstall-pdfmted)
@@ -99,15 +99,15 @@ Install all dependencies on Ubuntu with the following commands:
     sudo apt-get install yad libimage-exiftool-perl qpdf
 
 
-#### Ubuntu 18.04 or higher, Debian, Linux Mint, Pop!OS, Zorin OS, Elementary OS, and any other Linux distribution based on Debian or Ubuntu
+#### Most other Linux distribution based on Debian or Ubuntu
 
     sudo apt install libimage-exiftool-perl yad qpdf
 
-#### Fedora, and most other Linux distribution based on Fedora
+#### Fedora and most other Linux distribution based on Fedora
 
     sudo dnf install perl-Image-ExifTool yad qpdf
 
-#### Arch Linux, Manjaro
+#### Arch Linux or Manjaro
 
     sudo pacman -S perl-image-exiftool yad qpdf
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 **PDFMtEd** (**PDF** <b>M</b>e<b>t</b>adata <b>Ed</b>itor) is a set of tools designed to simplify working with PDF metadata on Linux. The utilities hosted in this repository are graphical front-ends to the marvelous [ExifTool](http://www.sno.phy.queensu.ca/~phil/exiftool/) by Phil Harvey.
 
+This repository is a fork of [glutanimate/PDFMtEd](https://github.com/glutanimate/PDFMtEd), ported to Python 3.
+
 ## Table of contents
 
 <!-- MarkdownTOC -->
@@ -103,7 +105,7 @@ Install all dependencies on Ubuntu with the following commands:
 - [YAD](http://sourceforge.net/projects/yad-dialog/): graphical front-end for bash scripts, a Zenity fork; provided by Webupd8 PPA
 - [ExifTool](http://www.sno.phy.queensu.ca/~phil/exiftool/): general purpose metadata editing application and library
 - [qpdf](http://qpdf.sourceforge.net/): command-line program that does structural, content-preserving transformations on PDF files; used in this project to restore broken PDF files and purge documents of residual metadata
-- Python 2.7 is required for the thumbnailer and thumbnail preview to work. This should be installed on your system by default.
+- Python 3 is required for the thumbnailer and thumbnail preview to work. This should be installed on your system by default.
 
 **Recommended:**
 

--- a/pdfmted-thumbnailer
+++ b/pdfmted-thumbnailer
@@ -1,4 +1,4 @@
-#!/usr/bin/python2.7
+#!/usr/bin/python3
 
 # General purpose GNOME thumbnailer script
 # Written by James Henstridge (http://askubuntu.com/a/201997)
@@ -18,19 +18,19 @@ def make_thumbnail(factory, filename):
     mime_type = info.get_content_type()
 
     if factory.lookup(uri, mtime) is not None:
-        print "FRESH       %s" % uri
+        print("FRESH       %s" % uri)
         return False
 
     if not factory.can_thumbnail(uri, mime_type, mtime):
-        print "UNSUPPORTED %s" % uri
+        print("UNSUPPORTED %s" % uri)
         return False
 
     thumbnail = factory.generate_thumbnail(uri, mime_type)
     if thumbnail is None:
-        print "ERROR       %s" % uri
+        print("ERROR       %s" % uri)
         return False
 
-    print "OK          %s" % uri
+    print("OK          %s" % uri)
     factory.save_thumbnail(thumbnail, uri, mtime)
     return True
 


### PR DESCRIPTION
I ported PDFMtEd to Python 3 and added installation instructions for other Linux distributions