### PR TITLE
Changed the editor to use the local cache directory

### DIFF
--- a/pdfmted-editor
+++ b/pdfmted-editor
@@ -33,7 +33,7 @@ EXECUTABLE="$(readlink -f "$0")"
 PROGDIR="${EXECUTABLE%/*}"
 THUMBNAILER="$PROGDIR/pdfmted-thumbnailer.py"
 # use RAMdisk instead of /tmp/ to improve performance
-TMPDIR="/run/shm/${0##*/}"
+TMPDIR="$HOME/.cache/PDFMtEd/${0##*/}"
 
 ############### SETTINGS #################
 


### PR DESCRIPTION
/run/ is not writable by a regular user, which causes two problems with the editor:

1. When you open the file to edit the metadata, the currently existing metadata in the file isn't populated in the fields (This is a huge pain in the ass if you need to edit the metadata of multiple files, have done some edits already, then have remembered you forgot some tags that you want to go back and add to the rest).
2. When you save a file you get an error saying there was a problem and that you can either try processing the document with sejda (which when tried also gives an error) or linearizing with qpdf (haven't tried that).

Changing the editor to use the local cache dir instead, fixes both of those problems.