### PR TITLE
Making the Editor look for the runtime dir in the right place

### DIFF
--- a/pdfmted-editor
+++ b/pdfmted-editor
@@ -33,7 +33,9 @@ EXECUTABLE="$(readlink -f "$0")"
 PROGDIR="${EXECUTABLE%/*}"
 THUMBNAILER="$PROGDIR/pdfmted-thumbnailer.py"
 # use RAMdisk instead of /tmp/ to improve performance
-TMPDIR="/run/shm/${0##*/}"
+TMPDIR="${XDG_RUNTIME_DIR:+$XDG_RUNTIME_DIR/PDFMtEd}" ; [ -z "$TMPDIR" ] && echo '$XDG_RUNTIME_DIR not set, defaulting to cache'
+TMPDIR="${TMPDIR:-$XDG_CACHE_HOME/PDFMtEd}"
+TMPDIR="${TMPDIR:-$HOME/.cache/PDFMtEd}"
 
 ############### SETTINGS #################
 


### PR DESCRIPTION
This PR does the following to set the Editor's TMPDIR variable:

If $XDG_RUNTIME_DIR is set, it uses $XDG_RUNTIME_DIR/PDFMtEd
else if $XDG_CACHE_HOME is set, it uses $XDG_CACHE_HOME/PDFMtEd
else it uses $HOME/.cache/PDFMtEd

Fixes #14 