### PR TITLE
Update uninstall.sh

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -7,7 +7,7 @@
 
 # Variables
 
-InstallPath="/usr/local"
+InstallPath="/usr"
 BinPath="$InstallPath/bin"
 LauncherPath="$InstallPath/share/applications"
 IconPath="$InstallPath/share/icons/hicolor/scalable/apps"


### PR DESCRIPTION
Changing /usr/local/ to /usr/ solves a lot of problems:
1. The problem with the folder not existing on some systems
2. Some distros don't allow the use of /usr/local/share/ and propose the usage of /usr/share/ instead

This way, it can be installed on every system without the problems.