### PR TITLE
python3 instead of python2.7 in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -18,7 +18,7 @@ IconPath="$InstallPath/share/icons/hicolor/scalable/apps"
 Application="PDFMtEd"
 InstallationFiles=("desktop/pdfmted-editor.desktop" "desktop/pdfmted-inspector.desktop"\
   "desktop/pdfmted.svg" "pdfmted-editor" "pdfmted-inspector" "pdfmted-thumbnailer")
-Dependencies=(yad exiftool python2.7 qpdf)
+Dependencies=(yad exiftool python3 qpdf)
 
 # Functions
 


### PR DESCRIPTION
Hello there !
I did a PR a while ago to port PDFMtEd to Python3 (#10 ), but I didn't notice python2.7 was still in the dependencies list, my bad
Issue fixed